### PR TITLE
authentication:　フロントとバックの認証の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ next-env.d.ts
 #仮想環境
 .venv
 
-**/__pycache__/**
+__pycache__
+camp-06

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -1,7 +1,9 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 import os
+from dotenv import load_dotenv
 
+load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -1,0 +1,13 @@
+#テーブルの初期化
+#Dockerを起動する上で、python init_db.pyを実行してください
+from db.database import engine, Base
+from db.models import User
+
+def create_tables():
+    """テーブル初期化"""
+    print("テーブル初期化中...")
+    Base.metadata.create_all(bind=engine)
+    print("テーブル初期化完了！")
+
+if __name__ == "__main__":
+    create_tables() 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,30 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from services.gemini import generate_recipe
+import os
+
+#開発環境の時使うテスト（Geminiへの接続のテスト）
+try:
+    from services.gemini import generate_recipe
+    HAS_GEMINI = True
+except (ValueError, ImportError):
+    HAS_GEMINI = False
+
 from db.database import Base, engine
 from routers import auth
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+#CORSの設定
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost:3001"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(auth.router)
 
@@ -20,5 +38,7 @@ async def read_main():
 
 @app.post("/generate-recipe")
 async def generate_recipe_endpoint(req: IngredientsRequest):
+    if not HAS_GEMINI:
+        raise HTTPException(status_code=503, detail="Gemini API not configured")
     recipe = await generate_recipe(req.ingredients)
     return {"recipe": recipe}

--- a/frontend/src/app/(authenticated)/login/components/LoginForm.tsx
+++ b/frontend/src/app/(authenticated)/login/components/LoginForm.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/contexts/AuthContext';
+
+export default function LoginForm() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
+    const router = useRouter();
+    const { login } = useAuth();
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        setError('');
+
+        try {
+        const response = await fetch('http://localhost:8000/auth/login', {
+            method: 'POST',
+            headers: {
+            'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+            email,
+            password,
+            }),
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            login(data.access_token);
+            router.push('/recipes');
+        } else {
+            if (data.detail && data.detail.includes('Invalid credentials')) {
+            router.push('/signup');
+            } else {
+            setError(data.detail || 'Login failed');
+            }
+        }
+        } catch (error) {
+        setError('Login failed. Please try again.');
+        } finally {
+        setLoading(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            メールアドレス
+            </label>
+            <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+        </div>
+        
+        <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            パスワード
+            </label>
+            <input
+            type="password"
+            id="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+        </div>
+
+        {error && (
+            <div className="text-red-600 text-sm">{error}</div>
+        )}
+
+        <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+        >
+            {loading ? 'Logging in...' : 'Login'}
+        </button>
+        </form>
+    );
+}

--- a/frontend/src/app/(authenticated)/login/page.tsx
+++ b/frontend/src/app/(authenticated)/login/page.tsx
@@ -1,0 +1,16 @@
+import LoginForm from './components/LoginForm';
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            ログイン
+          </h2>
+        </div>
+        <LoginForm />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(authenticated)/signup/components/SignupForm.tsx
+++ b/frontend/src/app/(authenticated)/signup/components/SignupForm.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/contexts/AuthContext';
+
+export default function SignupForm() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
+    const router = useRouter();
+    const { login } = useAuth();
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        setError('');
+
+        try {
+        const response = await fetch('http://localhost:8000/auth/register', {
+            method: 'POST',
+            headers: {
+            'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+            email,
+            password,
+            }),
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            login(data.access_token);
+            router.push('/recipes');
+        } else {
+            setError(data.detail || 'Registration failed');
+        }
+        } catch (error) {
+        setError('Registration failed. Please try again.');
+        } finally {
+        setLoading(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            メールアドレス
+            </label>
+            <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+        </div>
+        
+        <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            パスワード
+            </label>
+            <input
+            type="password"
+            id="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            />
+        </div>
+
+        {error && (
+            <div className="text-red-600 text-sm">{error}</div>
+        )}
+
+        <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+        >
+            {loading ? 'Registering...' : 'Sign Up'}
+        </button>
+        </form>
+    );
+}

--- a/frontend/src/app/(authenticated)/signup/page.tsx
+++ b/frontend/src/app/(authenticated)/signup/page.tsx
@@ -1,0 +1,16 @@
+import SignupForm from './components/SignupForm';
+
+export default function SignupPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            アカウント作成
+          </h2>
+        </div>
+        <SignupForm />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect } from 'react';
+
+interface AuthContextType {
+    isAuthenticated: boolean;
+    token: string | null;
+    login: (token: string) => void;
+    logout: () => void;
+    }
+
+    const AuthContext = createContext<AuthContextType | null>(null);
+
+    export function AuthProvider({ children }: { children: React.ReactNode }) {
+    const [token, setToken] = useState<string | null>(null);
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+    useEffect(() => {
+        const storedToken = localStorage.getItem('access_token');
+        if (storedToken) {
+        setToken(storedToken);
+        setIsAuthenticated(true);
+        }
+    }, []);
+
+    const login = (newToken: string) => {
+        localStorage.setItem('access_token', newToken);
+        setToken(newToken);
+        setIsAuthenticated(true);
+    };
+
+    const logout = () => {
+        localStorage.removeItem('access_token');
+        setToken(null);
+        setIsAuthenticated(false);
+    };
+
+    return (
+        <AuthContext.Provider value={{ isAuthenticated, token, login, logout }}>
+        {children}
+        </AuthContext.Provider>
+    );
+    }
+
+    export function useAuth() {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error('useAuth must be used within an AuthProvider');
+    }
+    return context;
+} 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import "tailwindcss";
 
 :root {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import "./globals.css";
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
+import { AuthProvider } from './contexts/AuthContext';
+import './globals.css';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 
 export default function RootLayout({
   children,
@@ -10,9 +11,11 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className="bg-gray-100 min-h-screen flex flex-col">
-        <Header />
-        <main className="flex-grow">{children}</main>
-        <Footer />
+        <AuthProvider>
+          <Header />
+          <main className="flex-grow">{children}</main>
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/lib/api.ts
+++ b/frontend/src/app/lib/api.ts
@@ -1,0 +1,52 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export interface LoginData {
+  email: string;
+  password: string;
+}
+
+export interface SignupData {
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  access_token: string;
+  token_type: string;
+}
+
+export const authApi = {
+  async login(data: LoginData): Promise<AuthResponse> {
+    const response = await fetch(`${API_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.detail || 'Login failed');
+    }
+
+    return response.json();
+  },
+
+  async register(data: SignupData): Promise<AuthResponse> {
+    const response = await fetch(`${API_BASE_URL}/auth/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.detail || 'Registration failed');
+    }
+
+    return response.json();
+  },
+};

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,49 @@
-import RecipeForm from "@/components/RecipeForm";
+'use client';
 
-export default function Home() {
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/app/contexts/AuthContext';
+
+export default function HomePage() {
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/recipes');
+    }
+  }, [isAuthenticated, router]);
+
+  if (isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md mx-auto text-center">
+          <p>Redirecting to recipes...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="py-10">
-      <RecipeForm />
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md mx-auto text-center">
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">Welcome to Recipe App</h1>
+        <div className="space-y-4">
+          <Link
+            href="/login"
+            className="block w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            Login
+          </Link>
+          <Link
+            href="/signup"
+            className="block w-full py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            Sign Up
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/recipes/page.tsx
+++ b/frontend/src/app/recipes/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/contexts/AuthContext';
+import RecipeForm from '@/components/RecipeForm';
+
+export default function RecipesPage() {
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isAuthenticated, router]);
+
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md mx-auto text-center">
+          <p>Redirecting to login...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">レシピ作成</h1>
+          <p className="text-gray-600">ようこそ！架空の国のレシピを作ってみましょう。</p>
+        </div>
+        <RecipeForm />
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,20 +1,61 @@
 "use client";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/app/contexts/AuthContext";
 
 export default function Header() {
+  const { isAuthenticated, logout } = useAuth();
+  const router = useRouter();
+
+  const handleLogoClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isAuthenticated) {
+      router.push('/recipes');
+    } else {
+      router.push('/');
+    }
+  };
+
+  const handleLogout = () => {
+    logout();
+    router.push('/');
+  };
+
   return (
     <header className="bg-indigo-600 text-white px-4 py-3">
       <nav className="max-w-4xl mx-auto flex flex-col sm:flex-row justify-between items-center gap-2 sm:gap-6">
-        <Link href="/" className="font-bold text-lg">
+        <button 
+          onClick={handleLogoClick}
+          className="font-bold text-lg hover:underline cursor-pointer"
+        >
           架空国家レシピ
-        </Link>
+        </button>
         <div className="flex gap-4">
-          <Link href="/" className="hover:underline">
-            トップ
-          </Link>
-          <Link href="/about" className="hover:underline">
-            説明
-          </Link>
+          {isAuthenticated ? (
+            <>
+              <button
+                onClick={handleLogoClick}
+                className="hover:underline"
+              >
+                レシピ
+              </button>
+              <button
+                onClick={handleLogout}
+                className="hover:underline text-red-200 hover:text-red-100"
+              >
+                ログアウト
+              </button>
+            </>
+          ) : (
+            <>
+              <Link href="/login" className="hover:underline">
+                ログイン
+              </Link>
+              <Link href="/signup" className="hover:underline">
+                サインアップ
+              </Link>
+            </>
+          )}
         </div>
       </nav>
     </header>

--- a/frontend/src/components/RecipeForm.tsx
+++ b/frontend/src/components/RecipeForm.tsx
@@ -45,11 +45,11 @@ export default function RecipeForm() {
             }
           }}
           placeholder="食材を入力 (例: トマト, 鶏肉)"
-          className="border p-2 flex-1 rounded"
+          className="border border-gray-300 p-2 flex-1 rounded text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
         />
         <button
           onClick={handleAddIngredient}
-          className="bg-green-600 text-white px-4 rounded"
+          className="bg-green-600 text-white px-4 rounded hover:bg-green-700"
         >
           追加
         </button>
@@ -65,14 +65,14 @@ export default function RecipeForm() {
         onClick={handleGenerate}
         disabled={ingredients.length === 0 || loading}
         className={`w-full py-2 rounded text-white ${
-          ingredients.length === 0 || loading ? "bg-gray-400" : "bg-blue-600"
+          ingredients.length === 0 || loading ? "bg-gray-400" : "bg-blue-600 hover:bg-blue-700"
         }`}
       >
         {loading ? "生成中..." : "レシピを生成"}
       </button>
 
       {recipe && (
-        <pre className="mt-6 whitespace-pre-wrap bg-gray-50 p-4 rounded border">
+        <pre className="mt-6 whitespace-pre-wrap bg-gray-50 p-4 rounded border text-gray-900">
           {recipe}
         </pre>
       )}


### PR DESCRIPTION
フロントとバックで変えたことをこちらで書くわ
まず、フロントの方

app
├---(authenticated) -> 認証部分
 |   |--login -> ログイン
 |       |--components 　
 |       |   |--LoginForm.tsx -> ログインフォーム
 |       |--page.tsx -> ログインページ
 |   |--signup -> サインアップ
 |      |--components
 |      |     |--SignupForm.tsx -> サインアップフォーム
 |      |--page.tsx -> サインアップページ
├---lib
 |    |--api.ts -> バックへの通信やデータの定義
├---contexts
 |    |--AuthContext.tsx -> ログインを管理する
├---recipes
 |    |--page.tsx
 
 バックエンドの部分
 main.pyをちょっと追加した、コメントあるからそこ見てて
init_db.pyはDockerへの初期操作（テーブルを作る）
database.pyはload_dotenvを追加した